### PR TITLE
Rename command and small tweaks

### DIFF
--- a/src/main/java/eu/pb4/holograms/mod/HologramCommand.java
+++ b/src/main/java/eu/pb4/holograms/mod/HologramCommand.java
@@ -295,7 +295,7 @@ public class HologramCommand {
                         .append(
                                 new TranslatableText("[%s] ", new LiteralText("" + x).formatted(Formatting.WHITE))
                                         .setStyle(Style.EMPTY
-                                                .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, "/holograms modify " + hologram.getName() + " lines set " + x))
+                                                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/holograms modify " + hologram.getName() + " lines set " + x))
                                                 .withColor(Formatting.DARK_GRAY)
                                         )
                                 )

--- a/src/main/java/eu/pb4/holograms/mod/HologramCommand.java
+++ b/src/main/java/eu/pb4/holograms/mod/HologramCommand.java
@@ -54,6 +54,14 @@ public class HologramCommand {
                                             .executes(HologramCommand::removeHologram)
                                     )
                             )
+                            .then(literal("rename")
+                                    .requires(Permissions.require("holograms.admin", 2))
+                                    .then(argument("name", StringArgumentType.word()).suggests(HologramCommand::hologramsSuggestion)
+                                        .then(argument("new_name", StringArgumentType.word())
+                                            .executes(HologramCommand::renameHologram)
+                                        )
+                                    )
+                            )
                             .then(literal("teleportTo")
                                     .requires(Permissions.require("holograms.admin", 2))
                                     .then(argument("name", StringArgumentType.word()).suggests(HologramCommand::hologramsSuggestion)
@@ -173,6 +181,28 @@ public class HologramCommand {
         } else {
             manager.removeHologram(name);
             context.getSource().sendFeedback(new TranslatableText("text.holograms.deleted", new LiteralText(name).formatted(Formatting.GOLD)), false);
+            return 1;
+        }
+    }
+
+    private static int renameHologram(CommandContext<ServerCommandSource> context) {
+        ServerWorld world = context.getSource().getWorld();
+        HologramManager manager = ((HoloServerWorld) world).getHologramManager();
+        String name = context.getArgument("name", String.class);
+        String new_name = context.getArgument("new_name", String.class);
+
+        if (!manager.hologramsByName.containsKey(name)) {
+            context.getSource().sendFeedback(new TranslatableText("text.holograms.invalid_hologram", new LiteralText(name).formatted(Formatting.GOLD)).formatted(Formatting.RED), false);
+            return 0;
+        } else {
+            if (manager.hologramsByName.containsKey(new_name)) {
+                context.getSource().sendFeedback(new TranslatableText("text.holograms.already_exist", new LiteralText(new_name).formatted(Formatting.GOLD)).formatted(Formatting.RED), false);
+            } else {
+                StoredHologram hologram = manager.hologramsByName.remove(name);
+                hologram.setName(new_name);
+                manager.hologramsByName.put(new_name, hologram);
+                context.getSource().sendFeedback(new TranslatableText("text.holograms.renamed", new LiteralText(name).formatted(Formatting.GOLD), new LiteralText(new_name).formatted(Formatting.GOLD)), false);
+            }
             return 1;
         }
     }

--- a/src/main/java/eu/pb4/holograms/mod/hologram/HologramManager.java
+++ b/src/main/java/eu/pb4/holograms/mod/hologram/HologramManager.java
@@ -103,7 +103,7 @@ public class HologramManager extends PersistentState {
 
     public void moveHologram(StoredHologram hologram, Vec3d vec3d) {
         hologram.hide();
-        for (ServerPlayerEntity player : hologram.getPlayerSet()) {
+        for (ServerPlayerEntity player : new HashSet<>(hologram.getPlayerSet())) {
             hologram.removePlayer(player);
         }
         Vec3d oldPos = hologram.getPosition();

--- a/src/main/java/eu/pb4/holograms/mod/hologram/PlaceholderMovingTextHologramElement.java
+++ b/src/main/java/eu/pb4/holograms/mod/hologram/PlaceholderMovingTextHologramElement.java
@@ -55,13 +55,7 @@ public class PlaceholderMovingTextHologramElement extends MovingTextHologramElem
         }
 
         if (clean) {
-            Set<UUID> uuids = this.cache.keySet();
-
-            for (UUID uuid : uuids) {
-                if (!this.cleanup.contains(uuid)) {
-                    this.cache.remove(uuid);
-                }
-            }
+            this.cache.keySet().removeIf(uuid -> !this.cleanup.contains(uuid));
             this.cleanup.clear();
         }
     }

--- a/src/main/java/eu/pb4/holograms/mod/hologram/PlaceholderStaticTextHologramElement.java
+++ b/src/main/java/eu/pb4/holograms/mod/hologram/PlaceholderStaticTextHologramElement.java
@@ -55,13 +55,7 @@ public class PlaceholderStaticTextHologramElement extends StaticTextHologramElem
         }
 
         if (clean) {
-            Set<UUID> uuids = this.cache.keySet();
-
-            for (UUID uuid : uuids) {
-                if (!this.cleanup.contains(uuid)) {
-                    this.cache.remove(uuid);
-                }
-            }
+            this.cache.keySet().removeIf(uuid -> !this.cleanup.contains(uuid));
             this.cleanup.clear();
         }
     }

--- a/src/main/java/eu/pb4/holograms/mod/hologram/StoredHologram.java
+++ b/src/main/java/eu/pb4/holograms/mod/hologram/StoredHologram.java
@@ -97,6 +97,10 @@ public class StoredHologram extends AbstractHologram {
         return this.position;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return this.name;
     }

--- a/src/main/resources/data/holograms/lang/en_us.json
+++ b/src/main/resources/data/holograms/lang/en_us.json
@@ -4,6 +4,7 @@
   "text.holograms.created": "Created hologram %s at position %s!",
   "text.holograms.moved": "Moved hologram %s to %s!",
   "text.holograms.deleted": "Deleted hologram %s!",
+  "text.holograms.renamed": "Renamed hologram %s to %s!",
   "text.holograms.removed_line": "Removed line \"%3$s\" (%2$s) from %1$s",
   "text.holograms.non_existing_line": "Line %2$s doesn't exist on %1$s!",
 


### PR DESCRIPTION
- Adds a rename command that allows to rename holograms
- Changes info click event from `COPY_TO_CLIPBOARD` to `SUGGEST_COMMAND` for easier use
- Fixed three ConcurrentModificationException that occured when multiple players were viewing holograms